### PR TITLE
wait during connect loop

### DIFF
--- a/RevoltSharp/RevoltClient.cs
+++ b/RevoltSharp/RevoltClient.cs
@@ -113,7 +113,9 @@ namespace RevoltSharp
             if (WebSocket != null)
             {
                 WebSocket.SetupWebsocket();
-                while (WebSocket.WebSocket == null || WebSocket.WebSocket.State != System.Net.WebSockets.WebSocketState.Open) { }
+                while (WebSocket.WebSocket == null || WebSocket.WebSocket.State != System.Net.WebSockets.WebSocketState.Open) {
+                    await Task.Delay(TimeSpan.FromMilliseconds(500));
+                }
             }
         }
 


### PR DESCRIPTION
This seems to fix a problem I was having, where the test bot would usually hang while connecting.

It also stops the library from using 100% cpu while connecting.